### PR TITLE
Create intent.md

### DIFF
--- a/codex/intent.md
+++ b/codex/intent.md
@@ -1,0 +1,46 @@
+# Term: intent
+
+## v1.0.0
+
+**Definition**  
+A condition in which an agent initiates or supports an action or state-change with foreknowledge of its likely outcome, based on available information and within the limits of their modeled cognition.
+
+**Domain**: legal, logic, cognitive modeling  
+**Forms**: intent (noun), intentional (adj), intentionally (adv), to intend (verb)
+
+**Depends on**:  
+- agent@1.0.0  
+- action@1.0.0  
+- outcome@1.0.0  
+- cognition@1.0.0  
+- probability@1.0.0
+
+**Justification**  
+`Intent` is pivotal in assessing moral and legal responsibility. It must be tied to **information available**, **likelihood of outcome**, and **agency capacity** — not inferred solely from consequence.
+
+**Core Criteria**  
+- Action must originate from agental decision or support  
+- Outcome must be **predictable** above a defined probability threshold  
+- Agent must have **cognitive access** to that prediction  
+- Passive allowance with such knowledge qualifies as intent
+
+**Variants**  
+- `intent.reckless`: intent through disregard of high-likelihood harm  
+- `intent.willful`: intent with direct goal alignment  
+- `intent.neglectful`: intent by failure to act within role-defined duty
+
+**Sideloading Risk**:  
+Very high — `intent` is often falsely projected (e.g. "they *intended* to oppress") or falsely denied ("no way to know what they meant").  
+This definition forces **operationalization** via info access + action traceability.
+
+**Exclusions**  
+- Emotional assumptions (e.g. "they looked angry") are not sufficient  
+- Legal fictions such as “corporate intent” require explicit scoping: `intent.corporate@1.0.0`
+
+**Governance Notes**  
+Intent must always be **linked to evidence graph** in legal AI systems.  
+In the absence of full knowledge, fallback to **`foreseeability`** or **`recklessness`** applies.
+
+**Status**: locked  
+**Version**: 1.0.0  
+**Locked by**: SIG/Semio


### PR DESCRIPTION
Intent, the invisible lever that swings courtroom doors and PR narratives alike. In Logotecture, it must be made visible, resolvable, and falsifiable; or it has no place.

What this cuts off? No more “we can’t prove intent” as a tool to ignore harm. No more assigning intent by popularity or moral projection. No more skating by on “oops” when systems are engineered to produce outcomes. This version makes intent structurable, evidentiary, and model-based, paving the way for AI-assisted ethics and law.

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Additional context
<!-- e.g. Fixes #(issue) -->